### PR TITLE
ci: bump all action refs (workflows + composites)

### DIFF
--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -46,7 +46,7 @@ runs:
           rustup target add "$t"
         done
         rustc --version
-    - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+    - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
     - shell: bash
       env:
         STEPS_SUB_OUTPUTS_PDF_OXIDE: ${{ steps.sub.outputs.pdf_oxide }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |


### PR DESCRIPTION
One owner for every `uses:` action ref in `.github` — workflow and
composite alike, no split with Dependabot:

- **whuppi/ci refs** across `.github` (workflows AND composite
  `action.yml`) swept uniform to the latest whuppi/ci release, so the
  pin never splits.
- **Every third-party action** (workflows AND composites) pinned to the
  latest SHA via pinact — including the refs inside composite
  `action.yml` that Dependabot can't read (dependabot-core#6704).

Dependabot owns pub deps only.

Add `ready-to-test` for the full cross-target run, then merge once green.

_Auto-generated by upgrade-check.yml_