### PR TITLE
test: mark hook_app_root_test dart:io-exempt

### DIFF
--- a/test/keep/hook_app_root_test.dart
+++ b/test/keep/hook_app_root_test.dart
@@ -7,6 +7,8 @@
 //
 // So this file tests the seam the others skip: the path from a hook's output
 // directory to a keep decision, plus a guard that the hook actually walks it.
+// io-exempt: builds a throwaway fixture app on disk — the hook's app-root
+// resolution can only be proven against a real directory tree.
 import 'dart:io';
 
 import 'package:pdf_manipulator/src/hook/app_root.dart';


### PR DESCRIPTION
`make test-guards` is red on `dev` right now, so `make check` fails before it reaches anything else. It has been since #209 landed.

The guard requires any test importing `dart:io` to say why: tests run identically on the VM and in a browser, and fixtures are imported Dart source rather than file I/O, so an unexplained `dart:io` import is usually a mistake. `hook_app_root_test.dart` is not a mistake — it builds a throwaway app on disk because the hook's app-root resolution can only be proven against a real directory tree, exactly the reason `detector_test.dart` already carries the exemption. It just shipped without the comment.

One comment, no behaviour change.

**Tests:** no new tests — this fixes a static guard. `make test-guards` passes with it and fails without it, which is the whole assertion.

**Breaking:** no.