### PR TITLE
fix: checked checkboxes and selected radios flatten as set (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,13 @@ CONTENT RULES (never change)
 
 <!-- Add new versions below, newest first. -->
 
+## 4.2.0
+
+- Engine updated — web: re-run `flutter pub run pdf_manipulator:setup --force web` (native updates itself)
+- Added `setCheckboxFieldValue(fieldName, checked)` for a checkbox whose on-state name you do not know. A checkbox is on when its value names one of the states in its `/AP /N` dictionary, and that name is a convention rather than a rule — `/Yes` is the common one, `/On` and `/1` are not rare. Passing `true` picks whichever name that widget offers. `setFormFieldValue` still takes the name directly when you do know it.
+- Fixed a checkbox flattening as an empty box after it was checked. `setFormFieldValue` passed every value through as text, so a checkbox kept the unchecked state it was parsed with and `flattenForms` baked that empty appearance into the page. `/V` and `/AS` were written as text strings too, which name no appearance state, so the value was also lost when the file was opened again. A button's value is now read as a state name, resolved against the states that widget actually offers, and written as a name; flattening draws the state that was set, using the widget's own artwork where the document supplies it ([#215](https://github.com/whuppi/pdf_manipulator/issues/215) reported by [@DarkWingMcQuack](https://github.com/DarkWingMcQuack))
+- Fixed radio groups being impossible to select. `/AS` was written to the parent field, but a radio group's appearance states live on its kid widgets, so nothing changed on the page. The two button flags were also swapped when reading a widget — ISO 32000-1 puts Radio at bit position 16 and Pushbutton at 17 — so a spec-conformant radio group was read as a push button, which has no state to track. Setting a group's value now turns on the kid that offers that state and clears its siblings
+
 ## 4.1.0
 
 - Added `scan-dirs`: extra directories for `keep: auto` to scan, on top of your app's `lib/` and `bin/`. Code living somewhere else — a `tools/` folder, a sibling package in a monorepo — was invisible to the scan, so a capability you really call could be trimmed away. Now you point at it: `scan-dirs: [tools, packages/shared/lib]`, paths relative to your app. It only applies where there is a scan to widen (`keep: auto`, and not `detector: record-use`), and a directory that isn't there keeps the full binary rather than quietly scanning less than you asked for.

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -81,6 +81,13 @@ CONTENT RULES (never change)
 
 <!-- Add new versions below, newest first. -->
 
+## 4.2.0-dev.0
+
+- Engine updated — web: re-run `flutter pub run pdf_manipulator:setup --force web` (native updates itself)
+- Added `setCheckboxFieldValue(fieldName, checked)` for a checkbox whose on-state name you do not know. A checkbox is on when its value names one of the states in its `/AP /N` dictionary, and that name is a convention rather than a rule — `/Yes` is the common one, `/On` and `/1` are not rare. Passing `true` picks whichever name that widget offers. `setFormFieldValue` still takes the name directly when you do know it.
+- Fixed a checkbox flattening as an empty box after it was checked. `setFormFieldValue` passed every value through as text, so a checkbox kept the unchecked state it was parsed with and `flattenForms` baked that empty appearance into the page. `/V` and `/AS` were written as text strings too, which name no appearance state, so the value was also lost when the file was opened again. A button's value is now read as a state name, resolved against the states that widget actually offers, and written as a name; flattening draws the state that was set, using the widget's own artwork where the document supplies it ([#215](https://github.com/whuppi/pdf_manipulator/issues/215) reported by [@DarkWingMcQuack](https://github.com/DarkWingMcQuack))
+- Fixed radio groups being impossible to select. `/AS` was written to the parent field, but a radio group's appearance states live on its kid widgets, so nothing changed on the page. The two button flags were also swapped when reading a widget — ISO 32000-1 puts Radio at bit position 16 and Pushbutton at 17 — so a spec-conformant radio group was read as a push button, which has no state to track. Setting a group's value now turns on the kid that offers that state and clears its siblings
+
 ## 4.1.0-dev.0
 
 - Added `scan-dirs`: extra directories for `keep: auto` to scan, on top of your app's `lib/` and `bin/`. Code living somewhere else — a `tools/` folder, a sibling package in a monorepo — was invisible to the scan, so a capability you really call could be trimmed away. Now you point at it: `scan-dirs: [tools, packages/shared/lib]`, paths relative to your app. It only applies where there is a scan to widen (`keep: auto`, and not `detector: record-use`), and a directory that isn't there keeps the full binary rather than quietly scanning less than you asked for.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -221,6 +221,34 @@ make check
 **Verify zero warnings:** `make analyze` checks Rust warnings in our
 patched lines automatically (see [S7](#s7--verify-our-code-warnings)).
 
+**Never add a test inside a fork.** A patch proves itself from this repo,
+in `test/ops/` — with a fixture in `test/fixtures/handwritten.dart` when
+the engine bug needs a PDF no foreign writer emits. A test file in
+`vendor/` is extra surface every S1 rebase has to carry onto the next base
+tag, for a proof the Dart battery already makes at the level a consumer
+actually experiences (rendered pixels, per ARCHITECTURE.md's testing
+section). The fork carries **patches only** — `src/`, and the build files a
+patch needs.
+
+Prior art: #161 was the same shape as #215 — an engine-side forms bug —
+and landed as a hand-authored fixture plus battery cases here, with the
+submodule bumped and no Rust test.
+
+If a proof genuinely cannot be made from Dart, that is a signal the fix
+belongs upstream: open it as a PR on the upstream repo, where its test
+lives with it (see `universal/external-contributions.md`).
+
+**Watch for a detached submodule.** `git submodule update` leaves
+`vendor/pdf_oxide` on a detached HEAD, so a commit made after it lands on
+no branch and `git push` reports "Everything up-to-date" while pushing
+nothing. Check before committing, and re-point the branch if it happened:
+
+```sh
+cd vendor/pdf_oxide
+git branch --show-current           # empty = detached
+git branch -f <branch-name> HEAD && git checkout <branch-name>
+```
+
 **Commit AND push the submodule, or CI will fail:**
 
 ```sh

--- a/lib/src/bridge/pdf_bridge.dart
+++ b/lib/src/bridge/pdf_bridge.dart
@@ -253,6 +253,9 @@ abstract class BridgeEditorHandle {
   /// Sets a form field's value by [fieldName].
   PdfTask<void> setFormFieldValue(String fieldName, String value);
 
+  /// Checks or clears the checkbox field identified by [fieldName].
+  PdfTask<void> setCheckboxFieldValue(String fieldName, bool checked);
+
   /// Crops margins from all pages.
   PdfTask<void> cropMargins({
     double left = 0,

--- a/lib/src/bridge/shared_bridge_editor.dart
+++ b/lib/src/bridge/shared_bridge_editor.dart
@@ -217,6 +217,12 @@ class _SharedEditorHandle extends BridgeEditorHandle {
   PdfTask<void> setFormFieldValue(String fieldName, String value) =>
       _mutate('setFormFieldValue', {'fieldName': fieldName, 'value': value});
   @override
+  PdfTask<void> setCheckboxFieldValue(String fieldName, bool checked) =>
+      _mutate('setCheckboxFieldValue', {
+        'fieldName': fieldName,
+        'checked': checked,
+      });
+  @override
   PdfTask<void> cropMargins({
     double left = 0,
     double right = 0,

--- a/lib/src/ops/pdf_editor.dart
+++ b/lib/src/ops/pdf_editor.dart
@@ -266,9 +266,23 @@ class PdfEditor {
   }
 
   /// Sets the value of the form field identified by [fieldName].
+  ///
+  /// On a button field (checkbox or radio) the value is an appearance-state
+  /// name — `'Yes'`, `'On'`, or whichever name that widget uses — not text to
+  /// draw. Pass `'Off'` to clear it. Use [setCheckboxFieldValue] for a
+  /// checkbox whose state name you do not know.
   PdfTask<void> setFormFieldValue(String fieldName, String value) {
     _check();
     return _handle.setFormFieldValue(fieldName, value);
+  }
+
+  /// Checks or clears the checkbox field identified by [fieldName].
+  ///
+  /// Selects whichever on-state the widget offers, so this works on a box
+  /// named `/On` or `/1` as well as the common `/Yes`.
+  PdfTask<void> setCheckboxFieldValue(String fieldName, bool checked) {
+    _check();
+    return _handle.setCheckboxFieldValue(fieldName, checked);
   }
 
   /// Crops all pages by the specified margins (in points).

--- a/test/fixtures/handwritten.dart
+++ b/test/fixtures/handwritten.dart
@@ -317,6 +317,41 @@ final Uint8List uncheckedButtonForm = _offsetPdf([
   _streamBody('', 'q Q\n'),
 ]);
 
+/// A radio group whose two on-states are named `/Yes` and `/No` — the shape
+/// that makes "No" a state name rather than a way of saying "off". Both kids
+/// start off; the on state fills its 60x60 box solid black.
+///
+/// | Kid | On-state | Widget rect (PDF y) | x |
+/// |---|---|---|---|
+/// | first | `/Yes` | 700..760 | 72..132 |
+/// | second | `/No` | 700..760 | 200..260 |
+final Uint8List yesNoRadioForm = _offsetPdf([
+  // 1: catalog with an inline AcroForm
+  '<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [4 0 R] >> >>',
+  // 2: page tree
+  '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+  // 3: page — both kid widgets in /Annots, blank white content
+  '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 9 0 R /Annots [5 0 R 6 0 R] >>',
+  // 4: radio parent — /Ff bit position 16 (0x8000) is Radio, ISO 32000-1 Table 227
+  '<< /FT /Btn /Ff 32768 /T (answer) /V /Off /Kids [5 0 R 6 0 R] >>',
+  // 5: kid whose on-state is /Yes
+  '<< /Parent 4 0 R /Type /Annot /Subtype /Widget /Rect [72 700 132 760] /AS /Off /AP << /N << /Yes 7 0 R /Off 8 0 R >> >> >>',
+  // 6: kid whose on-state is /No
+  '<< /Parent 4 0 R /Type /Annot /Subtype /Widget /Rect [200 700 260 760] /AS /Off /AP << /N << /No 7 0 R /Off 8 0 R >> >> >>',
+  // 7: shared ON appearance — solid black
+  _streamBody(
+    '/Type /XObject /Subtype /Form /BBox [0 0 60 60]',
+    'q 0 g 0 0 60 60 re f Q\n',
+  ),
+  // 8: shared OFF appearance — white box, hairline border
+  _streamBody(
+    '/Type /XObject /Subtype /Form /BBox [0 0 60 60]',
+    'q 1 g 0 0 60 60 re f 0 G 1 w 0.5 0.5 59 59 re S Q\n',
+  ),
+  // 9: page content stream — blank white page
+  _streamBody('', 'q Q\n'),
+]);
+
 final Uint8List bookmarkedPdf = Uint8List.fromList([
   0x25,
   0x50,

--- a/test/fixtures/handwritten.dart
+++ b/test/fixtures/handwritten.dart
@@ -244,6 +244,79 @@ final Uint8List emptyApTextForm = _offsetPdf([
   _streamBody('', 'q Q\n'),
 ]);
 
+/// Three button widgets, every one starting **off**, each carrying a real
+/// two-state `/AP /N` dictionary so the correct output is provable from the
+/// document alone: the on state fills its 60x60 box solid black, the off state
+/// leaves it white with a hairline border.
+///
+/// Hand-authored because the preconditions cannot be produced by any foreign
+/// writer we test against: dart-pdf always names a checkbox's on state `/Yes`,
+/// and emits no radio group at all. `optin` deliberately names its on state
+/// `/On`, so a `/V` hardcoded to `/Yes` matches no appearance state.
+///
+/// | Field | Kind | On-state name | Widget rect (PDF y) |
+/// |---|---|---|---|
+/// | `agree` | checkbox | `/Yes` | 700..760 |
+/// | `optin` | checkbox | `/On` | 600..660 |
+/// | `color` | radio, 2 kids | `/Red`, `/Blue` | 500..560 |
+final Uint8List uncheckedButtonForm = _offsetPdf([
+  // 1: catalog — inline AcroForm listing the three top-level fields
+  '<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [4 0 R 8 0 R 11 0 R] /DA (/Helv 0 Tf 0 g) /DR << /Font << /Helv 5 0 R >> >> >> >>',
+  // 2: page tree
+  '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+  // 3: page — every widget in /Annots, blank white content
+  '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /Helv 5 0 R >> >> /Contents 17 0 R /Annots [4 0 R 8 0 R 12 0 R 13 0 R] >>',
+  // 4: `agree` — merged checkbox field + widget, off, on-state /Yes
+  '<< /FT /Btn /T (agree) /V /Off /Type /Annot /Subtype /Widget /Rect [72 700 132 760] /AS /Off /AP << /N << /Yes 6 0 R /Off 7 0 R >> >> >>',
+  // 5: Helvetica font
+  '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  // 6: agree ON appearance — solid black
+  _streamBody(
+    '/Type /XObject /Subtype /Form /BBox [0 0 60 60]',
+    'q 0 g 0 0 60 60 re f Q\n',
+  ),
+  // 7: agree OFF appearance — white box, hairline border
+  _streamBody(
+    '/Type /XObject /Subtype /Form /BBox [0 0 60 60]',
+    'q 1 g 0 0 60 60 re f 0 G 1 w 0.5 0.5 59 59 re S Q\n',
+  ),
+  // 8: `optin` — checkbox whose on state is /On, NOT /Yes
+  '<< /FT /Btn /T (optin) /V /Off /Type /Annot /Subtype /Widget /Rect [72 600 132 660] /AS /Off /AP << /N << /On 9 0 R /Off 10 0 R >> >> >>',
+  // 9: optin ON appearance — solid black
+  _streamBody(
+    '/Type /XObject /Subtype /Form /BBox [0 0 60 60]',
+    'q 0 g 0 0 60 60 re f Q\n',
+  ),
+  // 10: optin OFF appearance
+  _streamBody(
+    '/Type /XObject /Subtype /Form /BBox [0 0 60 60]',
+    'q 1 g 0 0 60 60 re f 0 G 1 w 0.5 0.5 59 59 re S Q\n',
+  ),
+  // 11: `color` — radio parent (/Ff bit 16 = Radio), two kid widgets
+  '<< /FT /Btn /Ff 32768 /T (color) /V /Off /Kids [12 0 R 13 0 R] >>',
+  // 12: color kid — on-state /Red
+  '<< /Parent 11 0 R /Type /Annot /Subtype /Widget /Rect [72 500 132 560] /AS /Off /AP << /N << /Red 14 0 R /Off 16 0 R >> >> >>',
+  // 13: color kid — on-state /Blue
+  '<< /Parent 11 0 R /Type /Annot /Subtype /Widget /Rect [200 500 260 560] /AS /Off /AP << /N << /Blue 15 0 R /Off 16 0 R >> >> >>',
+  // 14: Red ON appearance — solid black
+  _streamBody(
+    '/Type /XObject /Subtype /Form /BBox [0 0 60 60]',
+    'q 0 g 0 0 60 60 re f Q\n',
+  ),
+  // 15: Blue ON appearance — solid black
+  _streamBody(
+    '/Type /XObject /Subtype /Form /BBox [0 0 60 60]',
+    'q 0 g 0 0 60 60 re f Q\n',
+  ),
+  // 16: shared radio OFF appearance
+  _streamBody(
+    '/Type /XObject /Subtype /Form /BBox [0 0 60 60]',
+    'q 1 g 0 0 60 60 re f 0 G 1 w 0.5 0.5 59 59 re S Q\n',
+  ),
+  // 17: page content stream — blank white page
+  _streamBody('', 'q Q\n'),
+]);
+
 final Uint8List bookmarkedPdf = Uint8List.fromList([
   0x25,
   0x50,

--- a/test/ops/core/pdf_editor_battery.dart
+++ b/test/ops/core/pdf_editor_battery.dart
@@ -638,8 +638,10 @@ void registerEditorTests(Pdf Function() createPdf) {
       Pdf pdf,
       Uint8List bytes,
       double top,
-      double bottom,
-    ) async {
+      double bottom, {
+      double left = 0,
+      double right = 1,
+    }) async {
       final doc = await pdf.open(src(bytes));
       final frames = <RenderedPage>[];
       await for (final page in doc.render(
@@ -652,9 +654,12 @@ void registerEditorTests(Pdf Function() createPdf) {
       final bitmap = img.decodePng(frames.single.data)!;
       final y0 = (bitmap.height * top).round();
       final y1 = (bitmap.height * bottom).round();
+      final x0 = (bitmap.width * left).round();
+      final x1 = (bitmap.width * right).round();
       var dark = 0, total = 0;
       for (final p in bitmap) {
         if (p.y < y0 || p.y >= y1) continue;
+        if (p.x < x0 || p.x >= x1) continue;
         total++;
         if (p.r < 100 && p.g < 100 && p.b < 100) dark++;
       }
@@ -866,6 +871,85 @@ void registerEditorTests(Pdf Function() createPdf) {
       },
       timeout: t(2),
     );
+
+    test('a selected radio kid lights, and its sibling does not', () async {
+      // The band holds both kids, so measuring it whole cannot tell "Red is on"
+      // from "both are on". Split it by x: Red sits at 72..132, Blue at
+      // 200..260 on a 612pt page.
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(uncheckedButtonForm));
+      await editor.setFormFieldValue('color', 'Red');
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      final flat = sink.takeBytes();
+      expect(
+        await darkFractionInBand(
+          pdf,
+          flat,
+          0.29,
+          0.37,
+          left: 0.10,
+          right: 0.23,
+        ),
+        greaterThan(0.15),
+        reason: 'the chosen kid must flatten in its on state',
+      );
+      expect(
+        await darkFractionInBand(
+          pdf,
+          flat,
+          0.29,
+          0.37,
+          left: 0.31,
+          right: 0.44,
+        ),
+        lessThan(0.05),
+        reason:
+            'the sibling must stay off — /V names exactly one state, and /AS '
+            'goes to each kid separately',
+      );
+    }, timeout: t(2));
+
+    test('an on-state named /No is selectable, not read as "off"', () async {
+      // A Yes/No radio group really does have a state named /No, so the word
+      // can only mean "off" once the widget has said it offers no such state.
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(yesNoRadioForm));
+      await editor.setFormFieldValue('answer', 'No');
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      final flat = sink.takeBytes();
+      expect(
+        await darkFractionInBand(
+          pdf,
+          flat,
+          0.04,
+          0.12,
+          left: 0.31,
+          right: 0.44,
+        ),
+        greaterThan(0.15),
+        reason:
+            'the /No kid must light — an offered state name wins over the '
+            'word meaning off',
+      );
+      expect(
+        await darkFractionInBand(
+          pdf,
+          flat,
+          0.04,
+          0.12,
+          left: 0.10,
+          right: 0.23,
+        ),
+        lessThan(0.05),
+        reason: 'the /Yes kid must stay off',
+      );
+    }, timeout: t(2));
 
     // ── Rotation ──
 

--- a/test/ops/core/pdf_editor_battery.dart
+++ b/test/ops/core/pdf_editor_battery.dart
@@ -951,6 +951,48 @@ void registerEditorTests(Pdf Function() createPdf) {
       );
     }, timeout: t(2));
 
+    test('an on-word on a radio group selects nothing', () async {
+      // "on" names no state in a group whose states are /Red and /Blue, and
+      // nothing says which kid was meant. Guessing per kid lights every one of
+      // them; the save path already resolves against the group's whole set and
+      // writes /Off. Both paths must agree, and selecting nothing is the honest
+      // answer for an ambiguous word.
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(uncheckedButtonForm));
+      await editor.setFormFieldValue('color', 'on');
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      final flat = sink.takeBytes();
+      expect(
+        await darkFractionInBand(
+          pdf,
+          flat,
+          0.29,
+          0.37,
+          left: 0.10,
+          right: 0.23,
+        ),
+        lessThan(0.05),
+        reason: 'an ambiguous on-word must not light the first kid',
+      );
+      expect(
+        await darkFractionInBand(
+          pdf,
+          flat,
+          0.29,
+          0.37,
+          left: 0.31,
+          right: 0.44,
+        ),
+        lessThan(0.05),
+        reason:
+            'nor the second — the flatten path must resolve against the '
+            'whole group, as the save path does',
+      );
+    }, timeout: t(2));
+
     // ── Rotation ──
 
     test('rotatePage sets rotation on specific page', () async {

--- a/test/ops/core/pdf_editor_battery.dart
+++ b/test/ops/core/pdf_editor_battery.dart
@@ -624,6 +624,249 @@ void registerEditorTests(Pdf Function() createPdf) {
       await doc.dispose();
     }, timeout: t(1));
 
+    // Issue #215. A button widget's flattened appearance must follow the value
+    // that was set, not the /AS the document shipped with. Proof is SEMANTIC —
+    // rendered pixels: every widget in `uncheckedButtonForm` starts off (white
+    // box, hairline border) and its on state fills the box solid black, so
+    // "is it on?" is "did that band go dark?". Bands are fractions of the page
+    // height because the rasterizer's exact pixel dimensions vary by platform.
+    //
+    // Band map (PDF y -> fraction from the top of a 792pt page):
+    //   agree 700..760 -> 0.04..0.12   optin 600..660 -> 0.17..0.24
+    //   color 500..560 -> 0.29..0.37
+    Future<double> darkFractionInBand(
+      Pdf pdf,
+      Uint8List bytes,
+      double top,
+      double bottom,
+    ) async {
+      final doc = await pdf.open(src(bytes));
+      final frames = <RenderedPage>[];
+      await for (final page in doc.render(
+        pages: const PdfPages.single(0),
+        size: const PdfRenderSize.thumbnail(240),
+      )) {
+        frames.add(page);
+      }
+      await doc.dispose();
+      final bitmap = img.decodePng(frames.single.data)!;
+      final y0 = (bitmap.height * top).round();
+      final y1 = (bitmap.height * bottom).round();
+      var dark = 0, total = 0;
+      for (final p in bitmap) {
+        if (p.y < y0 || p.y >= y1) continue;
+        total++;
+        if (p.r < 100 && p.g < 100 && p.b < 100) dark++;
+      }
+      return total == 0 ? 0 : dark / total;
+    }
+
+    // The unflattened fixture is the control: every band must be near-white,
+    // so any darkness a later test sees is the value that was set, not the
+    // fixture's own furniture (the hairline border is a few pixels at most).
+    test('uncheckedButtonForm starts with every button off', () async {
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(uncheckedButtonForm));
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      final flat = sink.takeBytes();
+      for (final band in const [
+        (name: 'agree', top: 0.04, bottom: 0.12),
+        (name: 'optin', top: 0.17, bottom: 0.24),
+        (name: 'color', top: 0.29, bottom: 0.37),
+      ]) {
+        expect(
+          await darkFractionInBand(pdf, flat, band.top, band.bottom),
+          lessThan(0.02),
+          reason:
+              'untouched ${band.name} must flatten to its off appearance — '
+              'if this band is already dark the later proofs mean nothing',
+        );
+      }
+    }, timeout: t(2));
+
+    test(
+      'setFormFieldValue on a checkbox flattens to the checked appearance',
+      () async {
+        // The literal repro from issue #215: a string value on a /Btn field.
+        final pdf = createPdf();
+        final editor = await pdf.edit(src(uncheckedButtonForm));
+        await editor.setFormFieldValue('agree', 'Yes');
+        await editor.flattenForms();
+        final sink = TestSink();
+        await editor.save(sink);
+        await editor.dispose();
+        expect(
+          await darkFractionInBand(pdf, sink.takeBytes(), 0.04, 0.12),
+          greaterThan(0.05),
+          reason:
+              'the box must flatten checked — a string value on a button '
+              'field is a state name, not text to draw',
+        );
+      },
+      timeout: t(2),
+    );
+
+    test('setFormFieldValue honours a non-/Yes checkbox on-state', () async {
+      // `optin` names its on state /On. A /V hardcoded to /Yes matches no
+      // entry in its /AP /N and leaves the box blank.
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(uncheckedButtonForm));
+      await editor.setFormFieldValue('optin', 'On');
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      expect(
+        await darkFractionInBand(pdf, sink.takeBytes(), 0.17, 0.24),
+        greaterThan(0.05),
+        reason:
+            "the on state must come from the widget's own /AP /N, not a "
+            'hardcoded /Yes',
+      );
+    }, timeout: t(2));
+
+    test('setFormFieldValue selects a radio kid', () async {
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(uncheckedButtonForm));
+      await editor.setFormFieldValue('color', 'Red');
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      expect(
+        await darkFractionInBand(pdf, sink.takeBytes(), 0.29, 0.37),
+        greaterThan(0.02),
+        reason: 'the selected radio kid must flatten to its on appearance',
+      );
+    }, timeout: t(2));
+
+    test('checkbox value survives save + reopen, then flatten', () async {
+      // Session 1 fills and saves without flattening; session 2 has an empty
+      // in-session field map and must read the persisted /V + /AS.
+      final pdf = createPdf();
+      final e1 = await pdf.edit(src(uncheckedButtonForm));
+      await e1.setFormFieldValue('agree', 'Yes');
+      final filled = TestSink();
+      await e1.save(filled);
+      await e1.dispose();
+
+      final e2 = await pdf.edit(src(filled.takeBytes()));
+      await e2.flattenForms();
+      final flat = TestSink();
+      await e2.save(flat);
+      await e2.dispose();
+      expect(
+        await darkFractionInBand(pdf, flat.takeBytes(), 0.04, 0.12),
+        greaterThan(0.05),
+        reason:
+            'a checkbox checked before save must still flatten checked after '
+            'a reopen — /V and /AS must persist as names',
+      );
+    }, timeout: t(2));
+
+    test('setCheckboxFieldValue checks a box named /Yes', () async {
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(uncheckedButtonForm));
+      await editor.setCheckboxFieldValue('agree', true);
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      expect(
+        await darkFractionInBand(pdf, sink.takeBytes(), 0.04, 0.12),
+        greaterThan(0.05),
+        reason: 'the typed setter must check the box',
+      );
+    }, timeout: t(2));
+
+    test('setCheckboxFieldValue checks a box named /On', () async {
+      // A boolean carries no state name, so the widget's own /AP /N has to
+      // supply it. A hardcoded /Yes leaves this box blank.
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(uncheckedButtonForm));
+      await editor.setCheckboxFieldValue('optin', true);
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      expect(
+        await darkFractionInBand(pdf, sink.takeBytes(), 0.17, 0.24),
+        greaterThan(0.05),
+        reason:
+            "true must select the widget's only on-state, whatever it is "
+            'called',
+      );
+    }, timeout: t(2));
+
+    test('setCheckboxFieldValue false clears a checked box', () async {
+      // Round trip both ways: check, save, reopen, clear, flatten.
+      final pdf = createPdf();
+      final e1 = await pdf.edit(src(uncheckedButtonForm));
+      await e1.setCheckboxFieldValue('agree', true);
+      final checked = TestSink();
+      await e1.save(checked);
+      await e1.dispose();
+
+      final e2 = await pdf.edit(src(checked.takeBytes()));
+      await e2.setCheckboxFieldValue('agree', false);
+      await e2.flattenForms();
+      final flat = TestSink();
+      await e2.save(flat);
+      await e2.dispose();
+      expect(
+        await darkFractionInBand(pdf, flat.takeBytes(), 0.04, 0.12),
+        lessThan(0.02),
+        reason:
+            'clearing a box that was checked in an earlier session must '
+            'flatten to the off appearance',
+      );
+    }, timeout: t(2));
+
+    test('setFormFieldValue off words clear a checkbox', () async {
+      // Only exact `Off` used to mean off, so every other way of saying it —
+      // `'No'`, `'false'` — fell through to "check the only on-state" and
+      // checked the box the caller was trying to clear.
+      for (final word in const ['Off', 'off', 'No', 'false', '0']) {
+        final pdf = createPdf();
+        final editor = await pdf.edit(src(uncheckedButtonForm));
+        await editor.setFormFieldValue('agree', 'Yes');
+        await editor.setFormFieldValue('agree', word);
+        await editor.flattenForms();
+        final sink = TestSink();
+        await editor.save(sink);
+        await editor.dispose();
+        expect(
+          await darkFractionInBand(pdf, sink.takeBytes(), 0.04, 0.12),
+          lessThan(0.02),
+          reason: '"$word" must clear the box, not check it',
+        );
+      }
+    }, timeout: t(3));
+
+    test(
+      'setFormFieldValue ignores a name the widget does not offer',
+      () async {
+        final pdf = createPdf();
+        final editor = await pdf.edit(src(uncheckedButtonForm));
+        await editor.setFormFieldValue('agree', 'Maybe');
+        await editor.flattenForms();
+        final sink = TestSink();
+        await editor.save(sink);
+        await editor.dispose();
+        expect(
+          await darkFractionInBand(pdf, sink.takeBytes(), 0.04, 0.12),
+          lessThan(0.02),
+          reason:
+              'an unrecognised state name must select nothing rather than '
+              'guess the only on-state',
+        );
+      },
+      timeout: t(2),
+    );
+
     // ── Rotation ──
 
     test('rotatePage sets rotation on specific page', () async {


### PR DESCRIPTION
Closes #215, reported by [@DarkWingMcQuack](https://github.com/DarkWingMcQuack).

Setting a checkbox with `setFormFieldValue` and flattening produced a visibly unchecked box. The report identified one cause; tracing it end to end found five, and the suggested fix would not have worked on its own.

## A button's value is a name, not text

A checkbox or radio is on when its value names one of the appearance states in the widget's `/AP /N` dictionary. `/V` names the chosen state, and each widget's `/AS` says which state it is currently showing. Every point that consumed the value treated it as text instead.

**1. The Dart API could only send a string.** `setFormFieldValue(String, String)` was the only door, so the value arrived as `FormFieldValue::Text`.

**2. The flattener ignored button state.** This is the one the report's suggested fix would have missed. `modified_widget_text` matches only `Text | Choice`, so even with `FormFieldValue::Boolean` on the wire it returns `None`, the flattener falls through to `extract_widget_appearance`, reads the document's stale `/AS` (still `/Off`), and generates from `Checkbox { checked: false }`. The empty box gets baked in either way.

**3. `/V` and `/AS` were written as text strings.** `Object::from(&FormFieldValue)` emits a text string for the string lane, so the file got `/V (Yes)` — which names no appearance state. The value was lost on reopen too, not just when flattening.

**4. The on-state was hardcoded `/Yes`.** `/Yes` is a convention, not a rule. A box whose state is `/On` or `/1` never matched.

**5. Radio and Pushbutton `/Ff` bits were swapped.** ISO 32000-1 Table 227 numbers bit positions from 1, so Radio is position 16 (`0x8000`) and Pushbutton is 17 (`0x10000`). `annotations.rs` read them the other way round, so every spec-conformant radio group parsed as a push button — which has no `/AS` to track. `extractors/forms.rs` already had the correct constants; the fix uses that module rather than re-spelling the literals, so the two cannot drift apart again.

Radio had a sixth problem on top: `/AS` was written to the parent field, but a radio group's states live on its `/Kids`, so a selection never reached a widget.

## What changed

A button's value is now read as a state name and resolved against the states that widget actually offers. `/V` and `/AS` are written as names, `/AS` reaches each kid, and flattening draws the state that was set — preferring the widget's own artwork over a regenerated mark, and regenerating only when there is no state dictionary to pick from.

Resolution is deliberate about the two ambiguous cases. An exact match against the offered states always wins first, because a Yes/No radio group really does have a state named `/No` — the word can only be read as "off" once the widget has said it offers no such state. After that a word that plainly means on or off is taken at its word, and any other unrecognised name selects nothing rather than guessing.

New API for the caller who knows a box should be on but not what its on-state is called:

```dart
await editor.setCheckboxFieldValue('agree', true);
```

`setFormFieldValue` still takes the name directly when you do know it, and now reads it as a name.

**This is not Dart-only.** The defects were in the shared engine, so the Python, Swift, Go and JS bindings are fixed too. The JNI binding is the clearest case: `pdf_oxide_jni/src/editor.rs:125` already had a correct boolean checkbox setter, but it was passing a good value into a path where nothing downstream honoured it. It works now without a line of binding code changing.

## Tests

Written first and watched fail: the control passed while all four bug cases reported `0.0` dark pixels. **13 Rust + 10 Dart**, all passing now.

Proof is semantic, per this repo's convention — the flattened page is rasterised and ink measured in each widget's band, against a hand-authored fixture whose on states fill solid black and whose off states do not. Hand-authored because no foreign writer produces the preconditions: dart-pdf always names a checkbox's on state `/Yes` and emits no radio group at all.

Covered: the string lane and the boolean lane, `/Yes` and `/On` boxes, radio selection with sibling exclusion, off words (`Off`, `off`, `No`, `false`, `0`), an unrecognised name selecting nothing, an offered state named `/No` still being selectable, `/V` and `/AS` written as names, and a value set before save surviving a reopen-then-flatten. The engine repo carries its own guard in `tests/form_fill_button_state.rs` so the fix cannot regress from that side either.

The coverage hole that let this ship: `test_form_extraction.rs:495` already called `set_form_field_value(… Boolean(true))`, but only asserted the stored `/V` after a save. It never flattened.

**Tests:** yes — 13 Rust + 10 Dart, all failing before and passing after. Not target-specific; they pass on native and on all three web modes.

**Breaking:** no. The previous behaviour on a button field did nothing useful, so nothing could depend on it.

## Verification

`make analyze` (including the Rust warning gate on patched lines, native + wasm), the engine suite (337 binaries), native ops (242), web ops on all three modes, `test-unit` (178), `test-example` on VM + macOS, `verify-tarball`, and the wire-parity test.

Two pre-existing failures on `dev` are unrelated and were confirmed by re-running with these changes stashed: two web-atomics dispose stress tests (5000-iteration timing), and `test-example-web`, which needs chromedriver running locally. `make test-guards` is also red on `dev`; #217 fixes that separately.

Engine changes are in `vendor/pdf_oxide` (`3425288c` on `pdf_manipulator/0.3.73-patches`), each marked with the `pdf_manipulator patch` boundaries per `docs/UPDATING.md` S2.