### PR TITLE
docs: point S8 at where release.sh actually lives

### DIFF
--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -500,10 +500,18 @@ changelog" step of the upload-assets job — right before the publish
 approval gate. Open the workflow run, expand that step, and review
 the full changelog that will be published.
 
-To preview locally:
+To preview locally, run the same mode the publish job runs. `release.sh`
+lives in the shared [whuppi/ci](https://github.com/whuppi/ci) repo, not
+this one — CI reaches it through the `release-tool` action, so locally you
+point at a checkout of that repo (a sibling of this one). Run from this
+package's root, and set `GITHUB_REPOSITORY` — the script requires it while
+loading, whichever mode you ask for, and exits without it. Some modes want
+more: `--check-versions` also needs `BRANCH` (`dev` or `prod`, picking the
+lane it checks). `--help` lists every mode.
 
 ```sh
-bash tool/ci/release.sh --stamp-changelog vX.Y.Z
+GITHUB_REPOSITORY=whuppi/pdf_manipulator \
+  bash ../ci/tool/ci/release.sh --stamp-changelog vX.Y.Z
 cat CHANGELOG.md
 git checkout CHANGELOG.md   # restore
 ```


### PR DESCRIPTION
`docs/UPDATING.md` S8 tells you to preview the pub.dev changelog with:

```sh
bash tool/ci/release.sh --stamp-changelog vX.Y.Z
```

That path holds `release_hooks.sh` and `upgrade.sh` — nothing else. `release.sh` moved to the shared [whuppi/ci](https://github.com/whuppi/ci) repo, which CI reaches through the `release-tool` action (`whuppi/ci/actions/release-tool@v2.4.0` in `release.yml`). Following the recipe gives "No such file or directory".

Now names the real location, plus the two preconditions the old recipe left out: run it from the package root, and set `GITHUB_REPOSITORY` — the script exits immediately without it, which is not obvious from the error.

Verified by running the documented command and confirming it builds the filtered changelog.

**Also stale, not fixed here** — flagging rather than widening a docs PR:
- `docs/ARCHITECTURE.md:273` draws a `tool/ci/` tree containing `release.sh` and `reconcile_test_json.sh`; neither is there, and `release_hooks.sh` is missing from the drawing.
- `CHANGELOG.md:15` and `CHANGELOG.pre.md:15` cite `tool/ci/release.sh --check-versions` inside the changelog standard. Same wrong path, but these are published artifacts, so worth deciding on separately.

**Tests:** none — documentation. The assertion is that the documented command runs, which I checked.

**Breaking:** no.