### PR TITLE
chore: reformat under the Flutter 3.47.2 formatter

### DIFF
--- a/test/ops/core/pdf_editor_battery.dart
+++ b/test/ops/core/pdf_editor_battery.dart
@@ -723,53 +723,49 @@ void registerEditorTests(Pdf Function() createPdf) {
       timeout: t(1),
     );
 
-    test(
-      'reopened filled form rasterizes its value (/NeedAppearances)',
-      () async {
-        // The renderer (not just the flattener) must regenerate a widget's
-        // appearance from /V when the AcroForm asks for it. Fill a field whose
-        // /AP is a blank placeholder, save (sets /V + /NeedAppearances), reopen,
-        // and RASTERIZE: the value's pixels must appear where the blank /AP would
-        // have drawn nothing. Proof is SEMANTIC — rendered pixels.
-        final pdf = createPdf();
-        final e1 = await pdf.edit(src(emptyApTextForm));
-        await e1.setFormFieldValue('field', 'JANEROE');
-        final filled = TestSink();
-        await e1.save(filled);
-        await e1.dispose();
+    test('reopened filled form rasterizes its value (/NeedAppearances)', () async {
+      // The renderer (not just the flattener) must regenerate a widget's
+      // appearance from /V when the AcroForm asks for it. Fill a field whose
+      // /AP is a blank placeholder, save (sets /V + /NeedAppearances), reopen,
+      // and RASTERIZE: the value's pixels must appear where the blank /AP would
+      // have drawn nothing. Proof is SEMANTIC — rendered pixels.
+      final pdf = createPdf();
+      final e1 = await pdf.edit(src(emptyApTextForm));
+      await e1.setFormFieldValue('field', 'JANEROE');
+      final filled = TestSink();
+      await e1.save(filled);
+      await e1.dispose();
 
-        final doc = await pdf.open(src(filled.takeBytes()));
-        final pages = <RenderedPage>[];
-        await for (final page in doc.render(
-          pages: const PdfPages.single(0),
-          size: const PdfRenderSize.thumbnail(220),
-        )) {
-          pages.add(page);
-        }
-        await doc.dispose();
+      final doc = await pdf.open(src(filled.takeBytes()));
+      final pages = <RenderedPage>[];
+      await for (final page in doc.render(
+        pages: const PdfPages.single(0),
+        size: const PdfRenderSize.thumbnail(220),
+      )) {
+        pages.add(page);
+      }
+      await doc.dispose();
 
-        final bitmap = img.decodePng(pages.single.data)!;
-        // In the broken case this page is provably blank white: empty /AP
-        // (/Tx BMC EMC), blank content (q Q), no widget border. So ANY ink in
-        // the top third — where the field sits — is the regenerated value.
-        // Count non-white pixels, not just near-black ones: a strict dark
-        // threshold reduces the small antialiased value to a few core pixels
-        // whose count varies by rasterizer/DPI across machines, while counting
-        // ink gives a strong 0-vs-many signal that survives those differences.
-        var ink = 0;
-        final cutoff = bitmap.height ~/ 3;
-        for (final p in bitmap) {
-          if (p.y < cutoff && (p.r < 200 || p.g < 200 || p.b < 200)) ink++;
-        }
-        expect(
-          ink,
-          greaterThan(10),
-          reason:
-              'the reopened value must rasterize, not the blank /AP placeholder',
-        );
-      },
-      timeout: t(1),
-    );
+      final bitmap = img.decodePng(pages.single.data)!;
+      // In the broken case this page is provably blank white: empty /AP
+      // (/Tx BMC EMC), blank content (q Q), no widget border. So ANY ink in
+      // the top third — where the field sits — is the regenerated value.
+      // Count non-white pixels, not just near-black ones: a strict dark
+      // threshold reduces the small antialiased value to a few core pixels
+      // whose count varies by rasterizer/DPI across machines, while counting
+      // ink gives a strong 0-vs-many signal that survives those differences.
+      var ink = 0;
+      final cutoff = bitmap.height ~/ 3;
+      for (final p in bitmap) {
+        if (p.y < cutoff && (p.r < 200 || p.g < 200 || p.b < 200)) ink++;
+      }
+      expect(
+        ink,
+        greaterThan(10),
+        reason:
+            'the reopened value must rasterize, not the blank /AP placeholder',
+      );
+    }, timeout: t(1));
 
     test('addImageStamp preserves PNG transparency', () async {
       // A transparent-background PNG keeps its transparency only if the


### PR DESCRIPTION
`make analyze` is red on `dev` right now, and has been since #214.

That PR bumped the SDK pin 3.44.8 → 3.47.2, which moves Dart 3.12.2 → 3.13.2 and with it the formatter. `test/ops/core/pdf_editor_battery.dart` was written under the old one and never re-run, so on current `dev`:

```
$ fvm dart format --output=none --set-exit-if-changed lib test bin tool hook
Changed test/ops/core/pdf_editor_battery.dart
Formatted 127 files (1 changed)      # exit 1
```

The change is one test's argument wrapping — a function literal that now fits inline, so the trailing commas around it go too.

## It is semantically inert

Verified rather than assumed: the file is identical to before once whitespace and trailing commas are ignored, which is the complete set of things a formatter may add or remove.

```
identical ignoring whitespace + trailing commas: True
```

Afterwards the whole tree is clean under the pinned SDK — `Formatted 143 files (0 changed)`, exit 0.

## Why it is worth landing first

It unblocks two other PRs that are failing for this reason and not their own:

- **#213** (action refs) — `Analyze` fails on this exact file, which #213 does not touch. Its own content is fine: `sccache-action v0.0.10 → v0.0.11` and `paths-filter v4.0.2 → v4.0.3`, both still the current latest and the only two actions behind on `dev`.
- **#212** (lockfiles) — same `Analyze`, same cause.

**#218** currently passes `Analyze` only because it is still behind #214; it fails the moment it takes the new pin, since it rewrites that same file. It will be reformatted when it is updated.

One caveat worth recording for whoever hits this next: measuring this in a worktree without `pub get` reports **11** dirty files instead of 1. Without package resolution, `analysis_options.yaml` cannot resolve its `include:` and the formatter falls back to an 80-column default. Always resolve deps before trusting a format count.

**Tests:** none — formatting only. The assertion is `dart format --set-exit-if-changed`, which fails on `dev` and passes here.

**Breaking:** no.