### PR TITLE
ci: hook-free fixtures, pinned sccache, complete wasm cache key, and the why behind every row

### DIFF
--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -31,6 +31,7 @@ runs:
     # dtolnay/rust-toolchain: it ships no version tags, so it can only be
     # pinned to a rolling master SHA.
     - name: Install Rust toolchain
+      id: toolchain
       shell: bash
       env:
         INPUTS_TARGETS: ${{ inputs.targets }}
@@ -46,7 +47,16 @@ runs:
           rustup target add "$t"
         done
         rustc --version
+        # Hoist the sccache pin for the action step below — a composite
+        # action's `with:` cannot source a file, so the pin crosses as an
+        # output. versions.env explains why it is pinned.
+        echo "sccache=$SCCACHE_VERSION" >> "$GITHUB_OUTPUT"
+    # `version:` MUST stay. Without it the action installs whatever sccache
+    # released last, and versions.env's SCCACHE_VERSION comment documents what
+    # that has cost. Bump the pin there, never here.
     - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      with:
+        version: v${{ steps.toolchain.outputs.sccache }}
     - shell: bash
       env:
         STEPS_SUB_OUTPUTS_PDF_OXIDE: ${{ steps.sub.outputs.pdf_oxide }}
@@ -54,7 +64,16 @@ runs:
       run: |
         {
           echo "SCCACHE_GHA_ENABLED=true"
+          # The cache namespace is chosen HERE, deliberately, instead of by
+          # whatever the sccache binary derives. Bump the number to purge every
+          # cached object on purpose (a poisoned or bloated cache); leave it
+          # alone across sccache and toolchain bumps — rustc's own hash is
+          # already part of every object key, so a toolchain bump never
+          # serves a stale object.
+          echo "SCCACHE_GHA_VERSION=1"
           echo "RUSTC_WRAPPER=sccache"
+          # Incremental artifacts are useless on a fresh runner and make
+          # sccache refuse to cache the crate. Keep this 0 in CI.
           echo "CARGO_INCREMENTAL=0"
           # crates.io fetches occasionally drop mid-transfer on CI (curl 56,
           # connection reset). cargo's default is 3 retries; 10 rides out a

--- a/.github/actions/capabilities/wasm-build/action.yml
+++ b/.github/actions/capabilities/wasm-build/action.yml
@@ -4,6 +4,12 @@ description: Compile WASM from source if not cached.
 runs:
   using: composite
   steps:
+    # File-existence is the whole gate, which is only safe because the
+    # wasm-cache key upstream names every input that shapes the file (see
+    # that capability). Never widen this to "reuse any wasm lying around"
+    # or download one built on another OS: the web rows on macOS/Windows
+    # exist precisely to prove THIS host's toolchain produces a working
+    # artifact, and a borrowed file makes that row pass without testing it.
     - shell: bash
       run: |
         if [ -f web_assets/pdf_oxide_bg.wasm ]; then

--- a/.github/actions/capabilities/wasm-cache/action.yml
+++ b/.github/actions/capabilities/wasm-cache/action.yml
@@ -4,8 +4,25 @@ description: Cache WASM build output to skip recompilation.
 runs:
   using: composite
   steps:
+    # The key must name EVERY input that changes the bytes of the wasm, and
+    # there are deliberately no restore-keys: the wasm-build capability trusts
+    # a restored file by its mere existence, so a partial-key match would
+    # silently run the browser rows against an artifact built from different
+    # features or a different toolchain — a green run proving nothing.
+    #   runner.os/arch        — wasm-bindgen + wasm-opt are host tools; the
+    #                           [P] web rows exist to prove each host builds
+    #                           a working artifact, so hosts never share one.
+    #   SUBMODULE_PDF_OXIDE   — the engine source AND bindgen_runner (it lives
+    #                           in the vendored workspace, so its Cargo.lock,
+    #                           i.e. the wasm-bindgen/wasm-opt versions, is
+    #                           covered by this rev).
+    #   build.json            — the wasm feature list.
+    #   tool/versions.env     — RUST_VERSION; the same source, different
+    #                           rustc, is a different wasm.
+    # Adding an input that shapes the wasm without adding it here reintroduces
+    # the stale-artifact hole.
     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: wasm-cache
       with:
         path: web_assets/pdf_oxide_bg.wasm
-        key: wasm-${{ runner.os }}-${{ runner.arch }}-${{ env.SUBMODULE_PDF_OXIDE }}
+        key: wasm-${{ runner.os }}-${{ runner.arch }}-${{ env.SUBMODULE_PDF_OXIDE }}-${{ hashFiles('build.json', 'tool/versions.env') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
               - 'Makefile'
               - '.github/**'
 
+  # Format + `dart analyze --fatal-infos` on the package and the example,
+  # then `cargo check` of the vendored engine under BOTH shipped feature
+  # sets (native and wasm) with our-code warnings fatal. The Rust half is
+  # what catches a patch that compiles for one target and not the other
+  # before a Full Test spends an hour on it. Needs submodules; does not
+  # need the engine BUILT — the fixtures target is deliberately hook-free.
   analyze:
     name: Analyze
     needs: [inputs, changes]
@@ -127,6 +133,12 @@ jobs:
           make-target: platforms
           rust: false  # pana is Dart-only static analysis, no native build to provision
 
+  # The fast gate's one real build: unit + native ops suites via `dart
+  # test`, which runs hook/build.dart exactly as a downstream package would.
+  # This is the only per-PR proof that the consumer hook still compiles the
+  # engine from vendor source on a clean machine — Full Test is opt-in by
+  # label, so if this job stops building the engine, a broken hook reaches
+  # `dev` unnoticed. Keep it a real build; cache its inputs, don't stub it.
   test:
     name: Package tests
     needs: [inputs, changes]
@@ -144,6 +156,12 @@ jobs:
 
   # Vendored-engine cargo tests — only when a PR touches the engine, its
   # features, the Makefile, or CI. Skipped on Dart-only PRs.
+  # This is the upstream suite running against OUR patches, with the
+  # test-only features the shipped builds exclude. A fork patch that breaks
+  # upstream behaviour we don't exercise from Dart is caught here only.
+  # The `rust` path filter is the trigger contract: widen it if the engine
+  # gains a new input; never narrow it to make Dart PRs faster (they
+  # already skip it).
   rust:
     name: Rust tests
     needs: [inputs, changes]

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -6,6 +6,14 @@
 # on any machine can build with this package. Each row declares
 # capabilities — make-target provisions them.
 #
+# Every row family below carries a comment naming the claim it proves
+# and what a shortcut would stop proving. That comment is the bar.
+# Make this workflow faster by caching what a row BUILDS (the shared
+# caches keyed on the real inputs); never by deleting a row, feeding it
+# another row's artifact, or building it with a lighter profile than
+# the one it exists to check. A row that passes without doing its own
+# work is a green light with nothing behind it.
+#
 # Runners: per-row in matrix (target-specific). Gate job uses
 # configurable infra runner (default: ubuntu-24.04).
 name: Full Test
@@ -91,6 +99,18 @@ jobs:
       matrix:
         include:
           # ── Package tests ──
+          # Native rows: the package's own suite against an engine the
+          # CONSUMER build hook compiled on that OS — the exact path a
+          # `dart test` in a downstream app takes, so a hook regression on
+          # one OS fails here and not in a user's project.
+          # Web rows: build the wasm on THIS host, then run the ops battery
+          # against that file in all three browser lanes (OPFS, JSPI,
+          # Atomics). The macOS/Windows [P] rows are not redundant with
+          # Linux: wasm-bindgen + wasm-opt run as host tools, so a
+          # host-specific difference (path handling, line endings, a
+          # toolchain that builds differently) only surfaces when that host
+          # builds the artifact it tests. Never hand these rows a
+          # Linux-built wasm.
           - { name: "pkg: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-pkg-native, timeout: 30 }
           - { name: "pkg: macOS (macos-arm64)",     runner: macos-14,            make: test-pkg-native, timeout: 30 }
           - { name: "pkg: Web (ubuntu-x64)",        runner: ubuntu-24.04,        make: test-ops-web,    timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
@@ -99,8 +119,19 @@ jobs:
           - { name: "pkg: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-pkg-native, timeout: 40 }
 
           # ── Integration tests ──
+          # The example app built the way a consumer builds it (the hook
+          # runs inside Gradle / Xcode / the desktop toolchain) and driven
+          # on a real device target. These rows are the only place the
+          # engine is loaded through Flutter's bundling on each platform.
           # Emulator needs Intel — macOS ARM runners are M1 VMs that can't virtualize the emulator:
           # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#limitations-for-arm64-macos-runners
+          # That is exactly why the macos-intel [P] row stays: it is the ONLY
+          # way CI can prove "a Mac host can build the Android side and run
+          # the integration tests" at all, and whuppi/ci uses this row as the
+          # canary that gates folding the Rust capability into the shared
+          # make-target. It is slow because its caches start cold, which is a
+          # caching problem — fix the cache, keep the row. Apple Silicon devs
+          # run this locally fine; only GitHub's ARM VMs can't.
           - { name: "int: Android (ubuntu-x64)",    runner: ubuntu-24.04,        make: test-example-android, timeout: 40, java: true, hw-accel: true, gradle-cache: true, emulator: true }
           - { name: "int: Android (macos-intel) [P]", runner: macos-15-intel,      make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
           - { name: "int: Android (win-x64) [P]",       runner: windows-2025-vs2026, make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
@@ -113,6 +144,15 @@ jobs:
           - { name: "int: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-example-windows, timeout: 40 }
 
           # ── Verify (release builds) ──
+          # Release-mode consumer builds: every shipped ABI through the hook
+          # with the release profile (fat LTO, codegen-units 1) — the
+          # binary users actually get — plus the post-build gates (16 KB
+          # ELF alignment on Android, the web gate). Integration rows above
+          # run debug builds, so an optimisation-only bug or a
+          # release-profile link failure is caught HERE and nowhere else.
+          # Never build these with a lighter profile to save minutes.
+          # The [P] rows prove a release build from a dev's Mac or Windows
+          # box yields the same shippable artifact, not just Linux CI's.
           - { name: "verify: Android (ubuntu-x64)", runner: ubuntu-24.04,        make: verify-android, timeout: 40, java: true, gradle-cache: true }
           - { name: "verify: Android (macos-arm64) [P]",runner: macos-14,            make: verify-android, timeout: 40, java: true, gradle-cache: true, portability: true }
           - { name: "verify: Android (win-x64) [P]",    runner: windows-2025-vs2026, make: verify-android, timeout: 60, java: true, gradle-cache: true, portability: true }

--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,19 @@ format:
 #                        builder battery is exempt wholesale — emitted
 #                        PDF syntax IS its subject)
 
+# Bare `dart`, NOT `dart run`. `dart run` fires every build hook in the
+# dependency graph before the script starts, so generating 13 pure-Dart
+# fixtures would first compile the native engine (fat-LTO cdylib, minutes)
+# in every target that depends on `fixtures` — including `analyze` and the
+# browser rows, which never load it. generate_fixtures.dart imports only
+# dart:* + crypto + the catalog. The consumer hook path loses no coverage:
+# `dart test` in test-unit / test-ops-native runs the hook on every PR.
+# The explicit `pub get` replaces the implicit resolve `dart run` did, so a
+# fresh clone still works; with an up-to-date lockfile it is a no-op.
+# Do not put `run` back "for consistency".
 fixtures:
-	$(DART) run tool/generate_fixtures.dart
+	@$(DART) pub get --no-example >/dev/null
+	$(DART) tool/generate_fixtures.dart
 
 # Two static guards. Guard 1: tests run identically on VM and browser, so no
 # dart:io; a test that genuinely needs it carries an 'io-exempt: <reason>'

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -767,6 +767,11 @@ Single matrix with two tiers in one sorted list:
 | Integration | macOS, Linux, Windows, Android, iOS, Web | Android on macos-intel + win, Web on macos + win |
 | Verify | Android, iOS, macOS, Linux, Web | Android on macos + win, Web on macos + win |
 
+Every row family states, in a comment beside it in `full-test.yml`, the
+claim it proves and what a build from a different host would silently stop
+proving. That comment is the contract: CI gets faster by caching what a row
+builds, never by removing the row or handing it another row's output.
+
 ### Build inputs — `build.json` vs `versions.env`
 
 Two files hold the project's pinned inputs, split by *what the value is*, not by

--- a/tool/versions.env
+++ b/tool/versions.env
@@ -22,6 +22,8 @@
 #   RUST_VERSION               — hand-bumped only. It is the engine's Minimum
 #       Supported Rust Version; it rises when the vendored crates actually need
 #       a newer toolchain, never automatically to "latest".
+#   SCCACHE_VERSION            — hand-bumped only, after a green Full Test with
+#       portability on (the Windows web rows are the ones a bump breaks).
 
 # The engine's Rust toolchain — ONE pinned version used two ways:
 #   • CI installs exactly this (`.github/actions/capabilities/rust`), so builds
@@ -36,6 +38,26 @@
 # requirement, so 1.92 is what actually builds. Re-probe when the render
 # stack moves: `cargo +<older> build` names the highest requirement.
 RUST_VERSION="1.92"
+
+# sccache — the rustc wrapper CI puts in front of every cargo build
+# (`.github/actions/capabilities/rust`). Pinned for two reasons:
+#   • Reproducibility: mozilla-actions/sccache-action installs "latest" when
+#     no version is passed, so an unpinned binary changes under CI on every
+#     upstream release with no commit in this repo.
+#   • Cache continuity: the GitHub-Actions cache namespace sccache writes to
+#     is derived from the binary, so a silent version change orphans every
+#     cached object at once — a whole-fleet cold build that looks like a
+#     random slowdown.
+# 0.16.0 is the last release with a green Windows web row: 0.17.0 re-spawns
+# rustc with web-sys's fully expanded `--check-cfg` argv and trips Windows'
+# 32,767-character command-line limit ("The filename or extension is too
+# long", os error 206 — mozilla/sccache#2397, #2815). No sha256 is tracked:
+# the action exposes only a version input and fetches from GitHub Releases.
+# Know its limit before expecting more from it: sccache cannot cache crates
+# that invoke the system linker (bin, cdylib, proc-macro), so the engine's
+# final cdylib — the fat-LTO step — is rebuilt every time regardless of hit
+# rate. sccache only saves the dependency crates.
+SCCACHE_VERSION="0.16.0"
 
 # pana — pub.dev's own analyzer, run by the `platforms` make target + CI job to
 # gate that the package still resolves to all 6 pub.dev platforms. `dart pub


### PR DESCRIPTION
## What

Four CI-only changes; no package code, no changelog entry (same as #213/#220).

1. **`make fixtures` uses bare `dart`, not `dart run`.** `dart run` fires every build hook before the script starts, so generating 13 pure-Dart fixtures compiled the native engine (fat-LTO cdylib) first — in *every* job depending on `fixtures`, including Analyze and the browser rows that never load it. Measured: 4.4 min per job. `dart test` in `test-unit`/`test-ops-native` still runs the hook on every PR, so the consumer-hook path keeps its per-PR proof. The explicit `pub get` replaces the implicit resolve `dart run` did.
2. **sccache pinned** (`SCCACHE_VERSION` in `tool/versions.env`, passed to `mozilla-actions/sccache-action` via `version:`), plus an explicit `SCCACHE_GHA_VERSION`. Unpinned, the binary floated: July's release ran 0.16.0, this week's runs 0.17.0, and 0.17.0 trips Windows' 32,767-char argv limit on `web-sys` (mozilla/sccache#2397, #2815) — the three failed Web (win-x64) rows on #218. Each float also changed the cache namespace, orphaning every cached object.
3. **wasm cache key** now includes `hashFiles('build.json','tool/versions.env')`. `wasm-build` skips the build on file existence alone, so a key that ignored the feature list and `RUST_VERSION` could serve a stale artifact to the browser rows.
4. **Comments that hold the bar.** Every job in `ci.yml` and every row family in `full-test.yml` now states what it proves and what a shortcut (borrowed artifact, lighter profile, deleted row) would stop proving. `docs/ARCHITECTURE.md` names that comment as the contract. Includes the reasoning for keeping `int: Android (macos-intel)`.

## Verification

- `actionlint` clean on all workflows; composites parse; `make lint-shell` clean.
- `make fixtures` in a fresh worktree: 13 fixtures generated, no `.dart_tool` hook output created (bare `dart` did not run the hook).

Companion: whuppi/ci PR fixing the Linux AVD cache key (`emunot-installed`); adopted here on the next whuppi/ci bump.