### PR TITLE
ci: cache diagnostics — restored-artifacts summary; probe dispatch input

### DIFF
--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -304,6 +304,22 @@ runs:
           ~/.cargo/registry/cache
           ~/.cargo/git/db
 
+    # What the restores actually brought back, per target triple: the
+    # engine outputs and their fingerprints. When a warm row still
+    # compiles, this line says whether the cache was missing something or
+    # cargo rejected what was there (then run Full Test with probe: true).
+    - name: Restored engine artifacts
+      if: inputs.cache == 'true'
+      shell: bash
+      run: |
+        for t in vendor/pdf_oxide/target/*/ vendor/pdf_oxide/target/*/*/; do
+          [ -d "$t/deps" ] || continue
+          so=$(find "$t/deps" -maxdepth 1 \( -name 'lib*_oxide.so' -o -name 'lib*_oxide.dylib' -o -name '*_oxide.dll' -o -name 'lib*_oxide.a' -o -name '*_oxide.wasm' \) 2>/dev/null | wc -l | tr -d ' ')
+          rl=$(find "$t/deps" -maxdepth 1 -name 'lib*_oxide*.rlib' 2>/dev/null | wc -l | tr -d ' ')
+          fp=$(find "$t/.fingerprint" -maxdepth 1 -name '*_oxide-*' 2>/dev/null | wc -l | tr -d ' ')
+          echo "  ${t#vendor/pdf_oxide/target/}: engine outputs=$so rlibs=$rl fingerprints=$fp"
+        done
+
     - name: Pin vendor source mtimes for cargo freshness
       if: inputs.cache == 'true'
       shell: bash

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -49,6 +49,10 @@ on:
         description: "Cold build — ignore the cargo cache (proves a fresh clone builds)"
         type: boolean
         default: false
+      probe:
+        description: "Diagnostic — log why cargo considers each unit dirty (CARGO_LOG fingerprint); use with a filter"
+        type: boolean
+        default: false
       portability:
         description: "Portability — test every valid runner per target"
         type: boolean
@@ -85,6 +89,9 @@ env:
   DEFAULT_PORTABILITY: 'true'
   # Cold on the weekly schedule and on `cold: true`; warm otherwise.
   RUST_CACHE: ${{ (github.event_name == 'schedule' || inputs.cold) && 'false' || 'true' }}
+  # probe: cargo prints, per unit, why it is rebuilding (dep-info stale,
+  # fingerprint mismatch, missing output). Verbose; dispatch-only.
+  CARGO_LOG: ${{ inputs.probe && 'cargo::core::compiler::fingerprint=info' || '' }}
   # Relative on purpose — the release sets this same value, and the
   # compile-* guard rows below rely on it to reproduce the release's
   # output layout (only the compile matrix reads it; other targets ignore it).


### PR DESCRIPTION
compile: Android hits both caches (the v2 engine archive is 500 MB) and still rebuilds all four ABIs while the other compile rows got faster. Two permanent diagnostics instead of another guess: the rust action prints, per target triple, how many engine outputs / rlibs / fingerprint dirs the restores brought back; and Full Test gains a `probe` dispatch input that sets `CARGO_LOG=cargo::core::compiler::fingerprint=info` so cargo names why each unit is dirty. Used with a row filter.