### PR TITLE
ci: whuppi/ci 2.7.0 → 2.7.1 (SDK cache key carries the runner image version)

### DIFF
--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -291,7 +291,7 @@ runs:
         } >> "$GITHUB_OUTPUT"
     - name: Restore Rust target (ghcr)
       if: inputs.cache == 'true' && inputs.ghcr-target == 'true'
-      uses: whuppi/ci/actions/capabilities/oci-cache@v2.7.0
+      uses: whuppi/ci/actions/capabilities/oci-cache@v2.7.1
       with:
         phase: restore
         name: rust-target

--- a/.github/actions/make-target/action.yml
+++ b/.github/actions/make-target/action.yml
@@ -148,7 +148,7 @@ runs:
     # the native/wasm ones (rust, wasm-cache, wasm-build) are pdf-specific and
     # stay local. The shared capabilities were generalized FROM these, so the
     # behavior is identical — only their home moved.
-    - uses: whuppi/ci/actions/capabilities/fvm@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/fvm@v2.7.1
       with:
         sdk-cache-backend: ${{ inputs.cache-backend }}
         cache-save: ${{ inputs.cache-save }}
@@ -185,22 +185,22 @@ runs:
         echo "free: ${avail_gb} GB, required: ${MIN_GB} GB"
         if [ "$avail_gb" -lt "$MIN_GB" ]; then echo "reclaim=true" >> "$GITHUB_OUTPUT"; else echo "reclaim=false" >> "$GITHUB_OUTPUT"; fi
 
-    - uses: whuppi/ci/actions/capabilities/free-disk-space@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/free-disk-space@v2.7.1
       if: inputs.free-disk == 'true' && steps.headroom.outputs.reclaim == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/java@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/java@v2.7.1
       if: inputs.java == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/chrome@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/chrome@v2.7.1
       if: inputs.chrome == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/headless-display@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/headless-display@v2.7.1
       if: inputs.headless-display == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/hw-accel@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/hw-accel@v2.7.1
       if: inputs.hw-accel == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.7.1
       if: inputs.gradle-cache == 'true'
       with:
         phase: restore
@@ -210,14 +210,14 @@ runs:
     # Forward the pdf_oxide submodule rev (set by the rust step above) as the
     # shared xcode-cache's key-extra, preserving the precise cache key the
     # local xcode-cache read from env directly.
-    - uses: whuppi/ci/actions/capabilities/xcode-cache@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/xcode-cache@v2.7.1
       if: inputs.xcode-cache == 'true'
       with:
         target: ${{ inputs.xcode-cache-target }}
         key-extra: ${{ env.SUBMODULE_PDF_OXIDE }}
         save: ${{ inputs.cache-save }}
 
-    - uses: whuppi/ci/actions/capabilities/pods-cache@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/pods-cache@v2.7.1
       if: inputs.pods-cache == 'true'
       with:
         save: ${{ inputs.cache-save }}
@@ -230,7 +230,7 @@ runs:
     - uses: ./.github/actions/capabilities/wasm-build
       if: inputs.wasm-build == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/ios-simulator@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/ios-simulator@v2.7.1
       if: inputs.simulator == 'true'
 
     # ── Run ──
@@ -270,7 +270,7 @@ runs:
     # by the capability's teardown-watchdog wrapper. The shared android-emulator
     # reconciles the machine report at its default path (test-results/
     # int-android.json), which is where the android make target writes.
-    - uses: whuppi/ci/actions/capabilities/android-emulator@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/android-emulator@v2.7.1
       if: inputs.emulator == 'true'
       with:
         script: /tmp/make-run.sh "${{ inputs.make-target }}"
@@ -278,7 +278,7 @@ runs:
         avd-cache-backend: ${{ inputs.cache-backend }}
         sdk-cache-backend: ${{ inputs.cache-backend == 'ghcr' && 'ghcr' || '' }}
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.7.0
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.7.1
       if: always() && inputs.gradle-cache == 'true'
       with:
         phase: save
@@ -290,7 +290,7 @@ runs:
     # read; dev writes). Skipped by oci-cache itself on an exact hit.
     - name: Save Rust target (ghcr)
       if: always() && inputs.rust == 'true' && inputs.rust-cache == 'true' && inputs.rust-ghcr-target == 'true'
-      uses: whuppi/ci/actions/capabilities/oci-cache@v2.7.0
+      uses: whuppi/ci/actions/capabilities/oci-cache@v2.7.1
       with:
         phase: save
         save: ${{ inputs.rust-cache-save }}

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -24,7 +24,7 @@ jobs:
   auto-close:
     permissions:
       issues: write  # label, comment on, and close resolved issues
-    uses: whuppi/ci/.github/workflows/auto-close.yml@v2.7.0
+    uses: whuppi/ci/.github/workflows/auto-close.yml@v2.7.1
     with:
       # Team slug for the humans (managed in the org, same team CODEOWNERS
       # uses) + the slopfairy bot as a fixed automation hook. A maintainer

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -21,4 +21,4 @@ jobs:
   cleanup:
     permissions:
       actions: write  # delete caches on refs/pull/N/merge
-    uses: whuppi/ci/.github/workflows/cache-cleanup.yml@v2.7.0
+    uses: whuppi/ci/.github/workflows/cache-cleanup.yml@v2.7.1

--- a/.github/workflows/debug-ssh.yml
+++ b/.github/workflows/debug-ssh.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - uses: whuppi/ci/actions/debug-ssh@v2.7.0
+      - uses: whuppi/ci/actions/debug-ssh@v2.7.1
 
       - name: Keep alive (touch /tmp/stop to end)
         shell: bash

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -233,7 +233,7 @@ jobs:
     steps:
       - name: Check filter
         id: filter
-        uses: whuppi/ci/actions/matrix-filter@v2.7.0
+        uses: whuppi/ci/actions/matrix-filter@v2.7.1
         with:
           name: ${{ matrix.name }}
           filter: ${{ needs.inputs.outputs.filter }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -23,4 +23,4 @@ jobs:
     permissions:
       contents: read  # checkout reads .github/labels.json
       issues: write   # labels are managed through the Issues API
-    uses: whuppi/ci/.github/workflows/labels.yml@v2.7.0
+    uses: whuppi/ci/.github/workflows/labels.yml@v2.7.1

--- a/.github/workflows/oci-cache-prune.yml
+++ b/.github/workflows/oci-cache-prune.yml
@@ -20,6 +20,6 @@ jobs:
   prune:
     permissions:
       packages: write  # delete versions of ghcr.io/whuppi/pdf_manipulator/cache
-    uses: whuppi/ci/.github/workflows/oci-cache-prune.yml@v2.7.0
+    uses: whuppi/ci/.github/workflows/oci-cache-prune.yml@v2.7.1
     with:
       retention-days: 14

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,7 +22,7 @@ jobs:
   checks:
     permissions:
       contents: read  # the reusable jobs only checkout + lint, read-only
-    uses: whuppi/ci/.github/workflows/pr-checks.yml@v2.7.0
+    uses: whuppi/ci/.github/workflows/pr-checks.yml@v2.7.1
 
   # Runs on PR activity (not just the daily cron, which GitHub disables after
   # ~60 idle days): HEADs every locally-pinned asset so a pruned pin fails the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,14 @@ jobs:
       # release a lane whose changelog adds more than one new version.
       # Checks the lane being released (the pushed branch).
       - name: Version sanity
-        uses: whuppi/ci/actions/release-tool@v2.7.0
+        uses: whuppi/ci/actions/release-tool@v2.7.1
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
         with:
           mode: --check-versions
       - name: Check changelog relevance
         id: check
-        uses: whuppi/ci/actions/release-tool@v2.7.0
+        uses: whuppi/ci/actions/release-tool@v2.7.1
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
           BEFORE: ${{ github.event.before }}
@@ -128,7 +128,7 @@ jobs:
           persist-credentials: false
       - name: Find + create release
         id: find
-        uses: whuppi/ci/actions/release-tool@v2.7.0
+        uses: whuppi/ci/actions/release-tool@v2.7.1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ inputs.branch || github.ref_name }}
@@ -250,21 +250,21 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Add git install snippet
-        uses: whuppi/ci/actions/release-tool@v2.7.0
+        uses: whuppi/ci/actions/release-tool@v2.7.1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --add-git-install
           tag: ${{ needs.discover.outputs.tag }}
       - name: Stamp asset hashes into tag
-        uses: whuppi/ci/actions/release-tool@v2.7.0
+        uses: whuppi/ci/actions/release-tool@v2.7.1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --update-tag-hashes
           tag: ${{ needs.discover.outputs.tag }}
       - name: Build pub.dev changelog for preview
-        uses: whuppi/ci/actions/release-tool@v2.7.0
+        uses: whuppi/ci/actions/release-tool@v2.7.1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -296,16 +296,16 @@ jobs:
           persist-credentials: false
       # Use the verified fvm capability, not an unverified pub global activate:
       # this job holds the pub.dev credentials, so don't weaken its tooling path.
-      - uses: whuppi/ci/actions/capabilities/fvm@v2.7.0
+      - uses: whuppi/ci/actions/capabilities/fvm@v2.7.1
       - name: Build filtered changelog
-        uses: whuppi/ci/actions/release-tool@v2.7.0
+        uses: whuppi/ci/actions/release-tool@v2.7.1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --stamp-changelog
           tag: ${{ needs.discover.outputs.tag }}
       - name: Flatten README banner for pub.dev
-        uses: whuppi/ci/actions/release-tool@v2.7.0
+        uses: whuppi/ci/actions/release-tool@v2.7.1
         with:
           mode: --stamp-readme
       - name: Ephemeral commit (clean git for pub publish)
@@ -325,7 +325,7 @@ jobs:
       - run: fvm dart pub get --no-example
       - run: fvm dart pub publish --force
       - name: Add pub.dev install snippet
-        uses: whuppi/ci/actions/release-tool@v2.7.0
+        uses: whuppi/ci/actions/release-tool@v2.7.1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -27,4 +27,4 @@ jobs:
   retry:
     permissions:
       actions: write  # gh run rerun re-runs the failed jobs of the run
-    uses: whuppi/ci/.github/workflows/retry.yml@v2.7.0
+    uses: whuppi/ci/.github/workflows/retry.yml@v2.7.1

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -29,4 +29,4 @@ jobs:
       contents: read        # labeler reads .github/labeler.yml + the PR file list
       issues: write         # assign maintainer on issue-opened events
       pull-requests: write  # apply labels, revoke ready-to-test, post notices
-    uses: whuppi/ci/.github/workflows/triage.yml@v2.7.0
+    uses: whuppi/ci/.github/workflows/triage.yml@v2.7.1

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: write       # pushes the chore/flutter-sdk + chore/lockfiles branches
       pull-requests: write  # opens / edits the upgrade PRs
-    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v2.7.0
+    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v2.7.1
     with:
       branch: dev
       sweepActions: true


### PR DESCRIPTION
The first Android SDK archives on GHCR were keyed with an empty image version; 2.7.1 reads ImageVersion in a step so the key rolls with runner-image updates.